### PR TITLE
Add Monitoring

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+    // monitoring
+    implementation 'io.micronaut.micrometer:micronaut-micrometer-registry-prometheus:5.8.0'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator:3.3.4'
+
      // springdoc
     implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:${springDocVersion}"
     implementation "org.springdoc:springdoc-openapi-starter-common:${springDocVersion}"

--- a/settings/application-default.properties
+++ b/settings/application-default.properties
@@ -54,3 +54,6 @@ mapping-service.pluginLocation=file://INSTALLATION_DIR/plugins
 # Absolute path to the local gemma mappings folder.
 mapping-service.mappingSchemasLocation=file://INSTALLATION_DIR/mappingSchemas
 mapping-service.jobOutput=file://INSTALLATION_DIR/jobOutput
+
+management.metrics.export.prometheus.enabled=true
+management.endpoint.metrics.enabled=true

--- a/src/main/java/edu/kit/datamanager/mappingservice/MappingServiceApplication.java
+++ b/src/main/java/edu/kit/datamanager/mappingservice/MappingServiceApplication.java
@@ -1,18 +1,15 @@
 package edu.kit.datamanager.mappingservice;
 
 import edu.kit.datamanager.mappingservice.configuration.ApplicationProperties;
-import edu.kit.datamanager.mappingservice.exception.MappingJobException;
 import edu.kit.datamanager.mappingservice.plugins.PluginManager;
-import java.io.File;
-import java.util.UUID;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+
+import io.micrometer.core.instrument.MeterRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -27,6 +24,13 @@ public class MappingServiceApplication {
 
     private static final Logger LOG = LoggerFactory.getLogger(MappingServiceApplication.class);
 
+    @Autowired
+    private final MeterRegistry meterRegistry;
+
+    MappingServiceApplication(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+    }
+
     @Bean
     public ApplicationProperties applicationProperties() {
         return new ApplicationProperties();
@@ -34,7 +38,7 @@ public class MappingServiceApplication {
 
     @Bean
     public PluginManager pluginManager() {
-        return new PluginManager(applicationProperties());
+        return new PluginManager(applicationProperties(), meterRegistry);
     }
 
     public static void main(String[] args) {

--- a/src/main/java/edu/kit/datamanager/mappingservice/configuration/StaticResourcesConfiguration.java
+++ b/src/main/java/edu/kit/datamanager/mappingservice/configuration/StaticResourcesConfiguration.java
@@ -15,7 +15,10 @@
  */
 package edu.kit.datamanager.mappingservice.configuration;
 
+import edu.kit.datamanager.mappingservice.rest.impl.PreHandleInterceptor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -28,9 +31,15 @@ import org.springframework.web.util.UrlPathHelper;
  */
 @Configuration
 public class StaticResourcesConfiguration implements WebMvcConfigurer {
+    private final PreHandleInterceptor preHandleInterceptor;
 
     private static final String[] CLASSPATH_RESOURCE_LOCATIONS = {
         "classpath:/static/"};
+
+    @Autowired
+    public StaticResourcesConfiguration(PreHandleInterceptor preHandleInterceptor) {
+        this.preHandleInterceptor = preHandleInterceptor;
+    }
 
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
@@ -42,5 +51,10 @@ public class StaticResourcesConfiguration implements WebMvcConfigurer {
         UrlPathHelper urlPathHelper = new UrlPathHelper();
         urlPathHelper.setUrlDecode(false);
         configurer.setUrlPathHelper(urlPathHelper);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(preHandleInterceptor);
     }
 }

--- a/src/main/java/edu/kit/datamanager/mappingservice/impl/MappingService.java
+++ b/src/main/java/edu/kit/datamanager/mappingservice/impl/MappingService.java
@@ -201,7 +201,7 @@ public class MappingService {
             LOGGER.trace("Mapping for id {} found. Creating temporary output file.");
             mappingRecord = optionalMappingRecord.get();
 
-            Counter.builder("mappings.plugin_usage").tag("plugin", mappingRecord.getMappingType()).register(meterRegistry).increment();
+            Counter.builder("mapping_service.plugin_usage").tag("plugin", mappingRecord.getMappingType()).register(meterRegistry).increment();
 
             Path mappingFile = Paths.get(mappingRecord.getMappingDocumentUri());
             // execute mapping

--- a/src/main/java/edu/kit/datamanager/mappingservice/impl/MappingService.java
+++ b/src/main/java/edu/kit/datamanager/mappingservice/impl/MappingService.java
@@ -29,6 +29,8 @@ import edu.kit.datamanager.mappingservice.plugins.MappingPluginException;
 import edu.kit.datamanager.mappingservice.plugins.MappingPluginState;
 import edu.kit.datamanager.mappingservice.plugins.PluginManager;
 import edu.kit.datamanager.mappingservice.util.FileUtil;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
@@ -88,6 +90,7 @@ public class MappingService {
     private Path jobsOutputDirectory;
 
     private ApplicationProperties applicationProperties;
+    private final MeterRegistry meterRegistry;
 
     /**
      * Logger for this class.
@@ -95,8 +98,9 @@ public class MappingService {
     private final static Logger LOGGER = LoggerFactory.getLogger(MappingService.class);
 
     @Autowired
-    public MappingService(ApplicationProperties applicationProperties) {
+    public MappingService(ApplicationProperties applicationProperties, MeterRegistry meterRegistry) {
         this.applicationProperties = applicationProperties;
+        this.meterRegistry = meterRegistry;
         init(this.applicationProperties);
     }
 
@@ -196,6 +200,9 @@ public class MappingService {
         if (optionalMappingRecord.isPresent()) {
             LOGGER.trace("Mapping for id {} found. Creating temporary output file.");
             mappingRecord = optionalMappingRecord.get();
+
+            Counter.builder("mappings.plugin_usage").tag("plugin", mappingRecord.getMappingType()).register(meterRegistry).increment();
+
             Path mappingFile = Paths.get(mappingRecord.getMappingDocumentUri());
             // execute mapping
             Path resultFile;

--- a/src/main/java/edu/kit/datamanager/mappingservice/plugins/PluginManager.java
+++ b/src/main/java/edu/kit/datamanager/mappingservice/plugins/PluginManager.java
@@ -65,7 +65,7 @@ public class PluginManager {
         this.applicationProperties = applicationProperties;
         reloadPlugins();
 
-        Gauge.builder("mapping_service.plugins-total", () -> plugins.size()).register(meterRegistry);
+        Gauge.builder("mapping_service.plugins_total", () -> plugins.size()).register(meterRegistry);
     }
 
     /**

--- a/src/main/java/edu/kit/datamanager/mappingservice/plugins/PluginManager.java
+++ b/src/main/java/edu/kit/datamanager/mappingservice/plugins/PluginManager.java
@@ -65,7 +65,7 @@ public class PluginManager {
         this.applicationProperties = applicationProperties;
         reloadPlugins();
 
-        Gauge.builder("mapping.plugins-total", () -> plugins.size()).register(meterRegistry);
+        Gauge.builder("mapping_service.plugins-total", () -> plugins.size()).register(meterRegistry);
     }
 
     /**

--- a/src/main/java/edu/kit/datamanager/mappingservice/plugins/PluginManager.java
+++ b/src/main/java/edu/kit/datamanager/mappingservice/plugins/PluginManager.java
@@ -65,7 +65,7 @@ public class PluginManager {
         this.applicationProperties = applicationProperties;
         reloadPlugins();
 
-        Gauge.builder("plugins-total", () -> plugins.size()).register(meterRegistry);
+        Gauge.builder("mapping.plugins-total", () -> plugins.size()).register(meterRegistry);
     }
 
     /**

--- a/src/main/java/edu/kit/datamanager/mappingservice/plugins/PluginManager.java
+++ b/src/main/java/edu/kit/datamanager/mappingservice/plugins/PluginManager.java
@@ -15,6 +15,8 @@
 package edu.kit.datamanager.mappingservice.plugins;
 
 import edu.kit.datamanager.mappingservice.configuration.ApplicationProperties;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,9 +61,11 @@ public class PluginManager {
      * instantiation time.
      */
     @Autowired
-    public PluginManager(ApplicationProperties applicationProperties) {
+    public PluginManager(ApplicationProperties applicationProperties, MeterRegistry meterRegistry) {
         this.applicationProperties = applicationProperties;
         reloadPlugins();
+
+        Gauge.builder("plugins-total", () -> plugins.size()).register(meterRegistry);
     }
 
     /**

--- a/src/main/java/edu/kit/datamanager/mappingservice/rest/impl/MappingAdministrationController.java
+++ b/src/main/java/edu/kit/datamanager/mappingservice/rest/impl/MappingAdministrationController.java
@@ -93,7 +93,7 @@ public class MappingAdministrationController implements IMappingAdministrationCo
         this.mappingService = mappingService;
         this.pluginManager = pluginManager;
 
-        Gauge.builder("mapping-schemes-total", mappingRecordDao::count).register(meterRegistry);
+        Gauge.builder("mapping.schemes-total", mappingRecordDao::count).register(meterRegistry);
     }
 
     @Override

--- a/src/main/java/edu/kit/datamanager/mappingservice/rest/impl/MappingAdministrationController.java
+++ b/src/main/java/edu/kit/datamanager/mappingservice/rest/impl/MappingAdministrationController.java
@@ -93,7 +93,7 @@ public class MappingAdministrationController implements IMappingAdministrationCo
         this.mappingService = mappingService;
         this.pluginManager = pluginManager;
 
-        Gauge.builder("mapping.schemes-total", mappingRecordDao::count).register(meterRegistry);
+        Gauge.builder("mapping_service.schemes-total", mappingRecordDao::count).register(meterRegistry);
     }
 
     @Override

--- a/src/main/java/edu/kit/datamanager/mappingservice/rest/impl/MappingAdministrationController.java
+++ b/src/main/java/edu/kit/datamanager/mappingservice/rest/impl/MappingAdministrationController.java
@@ -27,6 +27,8 @@ import edu.kit.datamanager.mappingservice.rest.IMappingAdministrationController;
 import edu.kit.datamanager.mappingservice.rest.PluginInformation;
 import edu.kit.datamanager.util.AuthenticationHelper;
 import edu.kit.datamanager.util.ControllerUtils;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.swagger.v3.core.util.Json;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -86,10 +88,12 @@ public class MappingAdministrationController implements IMappingAdministrationCo
      */
     private final MappingService mappingService;
 
-    public MappingAdministrationController(IMappingRecordDao mappingRecordDao, PluginManager pluginManager, MappingService mappingService) {
+    public MappingAdministrationController(IMappingRecordDao mappingRecordDao, PluginManager pluginManager, MappingService mappingService, MeterRegistry meterRegistry) {
         this.mappingRecordDao = mappingRecordDao;
         this.mappingService = mappingService;
         this.pluginManager = pluginManager;
+
+        Gauge.builder("mapping-schemes-total", mappingRecordDao::count).register(meterRegistry);
     }
 
     @Override

--- a/src/main/java/edu/kit/datamanager/mappingservice/rest/impl/MappingAdministrationController.java
+++ b/src/main/java/edu/kit/datamanager/mappingservice/rest/impl/MappingAdministrationController.java
@@ -93,7 +93,7 @@ public class MappingAdministrationController implements IMappingAdministrationCo
         this.mappingService = mappingService;
         this.pluginManager = pluginManager;
 
-        Gauge.builder("mapping_service.schemes-total", mappingRecordDao::count).register(meterRegistry);
+        Gauge.builder("mapping_service.schemes_total", mappingRecordDao::count).register(meterRegistry);
     }
 
     @Override

--- a/src/main/java/edu/kit/datamanager/mappingservice/rest/impl/MappingExecutionController.java
+++ b/src/main/java/edu/kit/datamanager/mappingservice/rest/impl/MappingExecutionController.java
@@ -29,6 +29,8 @@ import edu.kit.datamanager.mappingservice.plugins.MappingPluginException;
 import edu.kit.datamanager.mappingservice.plugins.MappingPluginState;
 import edu.kit.datamanager.mappingservice.rest.IMappingExecutionController;
 import edu.kit.datamanager.mappingservice.util.FileUtil;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,7 +51,7 @@ import java.nio.file.Path;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import org.apache.tomcat.util.file.Matcher;
+
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.MediaType;
@@ -70,11 +72,16 @@ public class MappingExecutionController implements IMappingExecutionController {
     private final MappingService mappingService;
     protected JobManager jobManager;
     private final IMappingRecordDao mappingRecordDao;
+    private final DistributionSummary documentsInSizeMetric;
+    private final DistributionSummary documentsOutSizeMetric;
 
-    public MappingExecutionController(MappingService mappingService, IMappingRecordDao mappingRecordDao, JobManager jobManager) {
+    public MappingExecutionController(MappingService mappingService, IMappingRecordDao mappingRecordDao, JobManager jobManager, MeterRegistry meterRegistry) {
         this.mappingService = mappingService;
         this.mappingRecordDao = mappingRecordDao;
         this.jobManager = jobManager;
+
+        this.documentsInSizeMetric = DistributionSummary.builder("mapping.documents.input-size").baseUnit("bytes").register(meterRegistry);
+        this.documentsOutSizeMetric = DistributionSummary.builder("mapping.documents.output-size").baseUnit("bytes").register(meterRegistry);
     }
 
     @Override
@@ -159,6 +166,8 @@ public class MappingExecutionController implements IMappingExecutionController {
             LOG.error(message, ex);
             throw new MappingExecutionException(message);
         } finally {
+            this.documentsInSizeMetric.record(document.getSize());
+            this.documentsOutSizeMetric.record(result.toFile().length());
             LOG.trace("Result file successfully transferred to client. Removing file {} from disk.", result);
             try {
                 Files.delete(result);

--- a/src/main/java/edu/kit/datamanager/mappingservice/rest/impl/MappingExecutionController.java
+++ b/src/main/java/edu/kit/datamanager/mappingservice/rest/impl/MappingExecutionController.java
@@ -82,8 +82,8 @@ public class MappingExecutionController implements IMappingExecutionController {
         this.mappingRecordDao = mappingRecordDao;
         this.jobManager = jobManager;
         this.meterRegistry = meterRegistry;
-        this.documentsInSizeMetric = DistributionSummary.builder("mapping_service.documents.input-size").baseUnit("bytes").register(meterRegistry);
-        this.documentsOutSizeMetric = DistributionSummary.builder("mapping_service.documents.output-size").baseUnit("bytes").register(meterRegistry);
+        this.documentsInSizeMetric = DistributionSummary.builder("mapping_service.documents.input_size").baseUnit("bytes").register(meterRegistry);
+        this.documentsOutSizeMetric = DistributionSummary.builder("mapping_service.documents.output_size").baseUnit("bytes").register(meterRegistry);
     }
 
     @Override

--- a/src/main/java/edu/kit/datamanager/mappingservice/rest/impl/MappingExecutionController.java
+++ b/src/main/java/edu/kit/datamanager/mappingservice/rest/impl/MappingExecutionController.java
@@ -82,8 +82,8 @@ public class MappingExecutionController implements IMappingExecutionController {
         this.mappingRecordDao = mappingRecordDao;
         this.jobManager = jobManager;
         this.meterRegistry = meterRegistry;
-        this.documentsInSizeMetric = DistributionSummary.builder("mapping.documents.input-size").baseUnit("bytes").register(meterRegistry);
-        this.documentsOutSizeMetric = DistributionSummary.builder("mapping.documents.output-size").baseUnit("bytes").register(meterRegistry);
+        this.documentsInSizeMetric = DistributionSummary.builder("mapping_service.documents.input-size").baseUnit("bytes").register(meterRegistry);
+        this.documentsOutSizeMetric = DistributionSummary.builder("mapping_service.documents.output-size").baseUnit("bytes").register(meterRegistry);
     }
 
     @Override
@@ -168,7 +168,7 @@ public class MappingExecutionController implements IMappingExecutionController {
             LOG.error(message, ex);
             throw new MappingExecutionException(message);
         } finally {
-            Counter.builder("mappings.mapping_usage").tag("mappingID", mappingID).register(meterRegistry).increment();
+            Counter.builder("mapping_service.mapping_usage").tag("mappingID", mappingID).register(meterRegistry).increment();
             this.documentsInSizeMetric.record(document.getSize());
             this.documentsOutSizeMetric.record(result.toFile().length());
 

--- a/src/main/java/edu/kit/datamanager/mappingservice/rest/impl/PreHandleInterceptor.java
+++ b/src/main/java/edu/kit/datamanager/mappingservice/rest/impl/PreHandleInterceptor.java
@@ -20,8 +20,8 @@ public class PreHandleInterceptor implements HandlerInterceptor {
 
     @Autowired
     PreHandleInterceptor(MeterRegistry meterRegistry) {
-        Gauge.builder("mapping_service.unique-users", uniqueUsers::size).register(meterRegistry);
-        counter = Counter.builder("mapping_service.requests-served").register(meterRegistry);
+        Gauge.builder("mapping_service.unique_users", uniqueUsers::size).register(meterRegistry);
+        counter = Counter.builder("mapping_service.requests_served").register(meterRegistry);
     }
 
     @Override

--- a/src/main/java/edu/kit/datamanager/mappingservice/rest/impl/PreHandleInterceptor.java
+++ b/src/main/java/edu/kit/datamanager/mappingservice/rest/impl/PreHandleInterceptor.java
@@ -20,8 +20,8 @@ public class PreHandleInterceptor implements HandlerInterceptor {
 
     @Autowired
     PreHandleInterceptor(MeterRegistry meterRegistry) {
-        Gauge.builder("mapping.unique-users", uniqueUsers::size).register(meterRegistry);
-        counter = Counter.builder("mapping.requests-served").register(meterRegistry);
+        Gauge.builder("mapping_service.unique-users", uniqueUsers::size).register(meterRegistry);
+        counter = Counter.builder("mapping_service.requests-served").register(meterRegistry);
     }
 
     @Override

--- a/src/main/java/edu/kit/datamanager/mappingservice/rest/impl/PreHandleInterceptor.java
+++ b/src/main/java/edu/kit/datamanager/mappingservice/rest/impl/PreHandleInterceptor.java
@@ -1,0 +1,38 @@
+package edu.kit.datamanager.mappingservice.rest.impl;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.security.MessageDigest;
+import java.util.HashSet;
+
+@Service
+public class PreHandleInterceptor implements HandlerInterceptor {
+    private final HashSet<String> uniqueUsers = new HashSet<>();
+    private final Counter counter;
+
+    @Autowired
+    PreHandleInterceptor(MeterRegistry meterRegistry) {
+        Gauge.builder("mapping.unique-users", uniqueUsers::size).register(meterRegistry);
+        counter = Counter.builder("mapping.requests-served").register(meterRegistry);
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, @Nullable HttpServletResponse response, @Nullable Object handler) throws Exception {
+        String ip = request.getRemoteAddr();
+        MessageDigest messageDigest = MessageDigest.getInstance("SHA-256");
+        messageDigest.update(ip.getBytes());
+        uniqueUsers.add(new String(messageDigest.digest()));
+
+        counter.increment();
+
+        return true;
+    }
+}

--- a/src/test/java/edu/kit/datamanager/mappingservice/TestConfig.java
+++ b/src/test/java/edu/kit/datamanager/mappingservice/TestConfig.java
@@ -6,6 +6,8 @@ package edu.kit.datamanager.mappingservice;
 
 import edu.kit.datamanager.mappingservice.configuration.ApplicationProperties;
 import edu.kit.datamanager.mappingservice.plugins.PluginManager;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -17,6 +19,8 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @ComponentScan("edu.kit.datamanager.mappingservice")
 public class TestConfig {
+    @Autowired
+    private MeterRegistry meterRegistry;
 
     @Bean
     public ApplicationProperties applicationProperties() {
@@ -25,6 +29,6 @@ public class TestConfig {
 
     @Bean
     public PluginManager pluginManager() {
-        return new PluginManager(applicationProperties());
+        return new PluginManager(applicationProperties(), meterRegistry);
     }
 }

--- a/src/test/java/edu/kit/datamanager/mappingservice/impl/MappingServiceTest.java
+++ b/src/test/java/edu/kit/datamanager/mappingservice/impl/MappingServiceTest.java
@@ -75,7 +75,6 @@ import org.springframework.web.client.ResourceAccessException;
 @TestPropertySource(properties = {"metastore.indexer.mappingsLocation=file:///tmp/metastore2/mapping"})
 //@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class MappingServiceTest {
-
     @Autowired
     ApplicationProperties applicationProperties;
 
@@ -85,13 +84,10 @@ public class MappingServiceTest {
     @Autowired
     MappingService mappingService4Test;
 
+    @Autowired
+    MeterRegistry meterRegistry;
+
     private final static String TEMP_DIR_4_MAPPING = "/tmp/mapping-service/";
-
-    private final MeterRegistry meterRegistry;
-
-    MappingServiceTest(MeterRegistry meterRegistry) {
-        this.meterRegistry = meterRegistry;
-    }
 
     @BeforeEach
     public void setUp() {

--- a/src/test/java/edu/kit/datamanager/mappingservice/impl/MappingServiceTest.java
+++ b/src/test/java/edu/kit/datamanager/mappingservice/impl/MappingServiceTest.java
@@ -22,6 +22,7 @@ import edu.kit.datamanager.mappingservice.domain.MappingRecord;
 import edu.kit.datamanager.mappingservice.exception.MappingException;
 import edu.kit.datamanager.mappingservice.exception.MappingNotFoundException;
 import edu.kit.datamanager.mappingservice.plugins.MappingPluginException;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -86,6 +87,12 @@ public class MappingServiceTest {
 
     private final static String TEMP_DIR_4_MAPPING = "/tmp/mapping-service/";
 
+    private final MeterRegistry meterRegistry;
+
+    MappingServiceTest(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+    }
+
     @BeforeEach
     public void setUp() {
         try {
@@ -103,7 +110,7 @@ public class MappingServiceTest {
 
     @Test
     public void testConstructor() throws URISyntaxException {
-        new MappingService(applicationProperties);
+        new MappingService(applicationProperties, meterRegistry);
     }
 
     @Test
@@ -115,7 +122,7 @@ public class MappingServiceTest {
             ap.setMappingsLocation(relativePath);
             File file = new File(relativePath.getPath());
             assertFalse(file.exists());
-            new MappingService(ap);
+            new MappingService(ap, meterRegistry);
             assertTrue(file.exists());
             FileUtils.deleteDirectory(file);
             assertFalse(file.exists());
@@ -127,7 +134,7 @@ public class MappingServiceTest {
     @Test
     public void testConstructorFailing() throws IOException, URISyntaxException {
         try {
-            new MappingService(null);
+            new MappingService(null, meterRegistry);
             fail();
         } catch (MappingException ie) {
             assertTrue(true);


### PR DESCRIPTION
Adds the following 8 metrics to be scraped by prometheus:
- `mapping_service.plugin_usage` Usage of each plugin, distinguished by tag
- `mapping_service.mapping_usage` Usage of each mapping, distinguished by tag
- `mapping_service.plugins_total` Number of installed plugins
- `mapping_service.schemes_total` Number of stored mapping schemes
- `mapping_service.documents.input_size` Byte size of documents uploaded to mapping service
- `mapping_service.documents.output_size` Byte size of documents produced by mapping service
- `mapping_service.unique_users` Unique users distinguished by IP. Hashed and stored in memory
- `mapping_service.requests_served` Number of API requests served (any response code)

I'm not sure if they all are adequately named or placed in the correct spot. I have already verified that all of the metrics work as expected, although in a limited local environment.