### PR TITLE
Improve log message on failed requirements installation for plugin due to missing expected file

### DIFF
--- a/src/main/java/edu/kit/datamanager/mappingservice/plugins/AbstractPythonMappingPlugin.java
+++ b/src/main/java/edu/kit/datamanager/mappingservice/plugins/AbstractPythonMappingPlugin.java
@@ -211,7 +211,7 @@ public abstract class AbstractPythonMappingPlugin implements IMappingPlugin {
                         throw new PluginInitializationFailedException("Failed to install plugin requirements. Status: " + venvState.getState());
                     }
                 } else {
-                    LOGGER.info("No requirements file found. Skipping dependency installation.");
+                    LOGGER.warn("No requirements.dist.txt file found. Skipping dependency installation.");
                 }
             } else {
                 throw new PluginInitializationFailedException("Venv installation has failed. Status: " + venvState.getState());


### PR DESCRIPTION
- specify expected file name for requirements file in log message
  - reasoning: it wouldn't be a default for a python project to have file with this exact name, so the expected file name should be documented / explained. This change provides at least basic explanation on failure.
- bump log level to warning
  - reasoning: not having the need to install any requirements, and therefore lacking the file completely, is likely a very rare case for plugins, so it should not throw an error, but a warning is warranted.